### PR TITLE
fix: use `getSemanticHTML()` instead of `root.innerHTML`

### DIFF
--- a/src/components/QuillyEditor.vue
+++ b/src/components/QuillyEditor.vue
@@ -59,7 +59,7 @@ const initialize = (QuillClass: typeof Quill) => {
 
   // Handle editor text change
   quill.on('text-change', (delta, oldContent, source) => {
-    model.value = quill.root.innerHTML
+    model.value = quill.getSemanticHTML()
     emit('text-change', { delta, oldContent, source })
   })
 
@@ -82,7 +82,7 @@ watch(
     if (!quillInstance) return
     if (newValue && newValue !== model.value) {
       pasteHTML(quillInstance)
-      model.value = quillInstance.root.innerHTML
+      model.value = quillInstance.getSemanticHTML()
     } else if (!newValue) {
       quillInstance.setContents([])
     }


### PR DESCRIPTION
This PR references the issue https://github.com/slab/quill/issues/4438 and #7 

Quill renders bullet lists as ordered lists with an HTML tag that other systems can't understand.

Based on the comment https://github.com/slab/quill/issues/3957#issuecomment-1945538748 I think Quilly should not use `quill.root.innerHTML` but `quill.getSemanticHTML()` instead.